### PR TITLE
Extending Columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ If you access your resource, and edit some data, you will now see the audits tab
 
 In case you need to add a column to the AuditsRelationManager that does
 not already exist in the table, you can add it in the config using the format denoted in the example below, and it will be
-prepended to the table builder. The name of the column to be added is the key of an associative array that contains other information about the class, as shown in the example below. The class instance of the column must be added, but the methods can be left out if not required, or added wherever necessary.
+prepended to the table builder. The name of the column to be added is the key of an associative array that contains other information about the class, as shown in the example below. The class instance of the column must be added, but the methods can be left out if not required, or added wherever necessary. 
 
 ```php
 <?php
@@ -96,11 +96,14 @@ return [
 ];
 ```
 
+
 After adding this information in the config, please run this command for changes to take place.
 
 ```bash
 php artisan optimize
 ```
+
+As things stand, methods with two required parameters are not supported.
 
 ### Permissions
 

--- a/README.md
+++ b/README.md
@@ -3,12 +3,14 @@
 A Filament plugin for [Laravel Auditing](https://laravel-auditing.com/) package.
 This plugin contains a relation manager for audits that you can add to your Filament resources.
 
-This package provides a Filament resource manager that shows a table with all audits on view and edit pages and allows restore audits.
+This package provides a Filament resource manager that shows a table with all audits on view and edit pages and allows
+restore audits.
 
 ## Installation
 
 > **Note**
-> This plugin uses the [Laravel Auditing](https://laravel-auditing.com/) package. First install and configure this package.
+> This plugin uses the [Laravel Auditing](https://laravel-auditing.com/) package. First install and configure this
+> package.
 
 You can install the plugin via composer:
 
@@ -47,11 +49,12 @@ return [
 ];
 ```
 
-The `audits_sort` can be used to change the default sort on the audits table. 
+The `audits_sort` can be used to change the default sort on the audits table.
 
 ## Usage
 
-To show the audits table in your Filament resource, just add `AuditsRelationManager::class` on your resource's `getRelations` method:
+To show the audits table in your Filament resource, just add `AuditsRelationManager::class` on your
+resource's `getRelations` method:
 
 ```php
 use Tapp\FilamentAuditing\RelationManagers\AuditsRelationManager;
@@ -70,9 +73,10 @@ That's it, you're all set!
 If you access your resource, and edit some data, you will now see the audits table on edit and view pages.
 
 ### Extending Columns
+
 In case you need to add a column to the AuditsRelationManager that does
-not already exist in the table, you can add it in the config, and it will be
-prepended to the table builder.
+not already exist in the table, you can add it in the config using the format denoted in the example below, and it will be
+prepended to the table builder. The name of the column to be added is the key of an associative array that contains other information about the class, as shown in the example below. The class instance of the column must be added, but the methods can be left out if not required, or added wherever necessary.
 
 ```php
 <?php
@@ -80,13 +84,23 @@ prepended to the table builder.
 return [
 
     'audits_extend' => [
-       \Filament\Tables\Columns\TextColumn::make('url'),
-       \Filament\Tables\Columns\TextColumn::make('ip_address'),
+       'url' => [
+           'class' => \Filament\Tables\Columns\TextColumn::class, // required
+           'methods' => [
+               'sortable',
+               'default' => 'NIL',
+            ],
+        ],
     ]
 
 ];
 ```
 
+After adding this information in the config, please run this command for changes to take place.
+
+```bash
+php artisan optimize
+```
 
 ### Permissions
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ return [
     'audits_sort' => [
         'column' => 'created_at',
         'direction' => 'desc',
+    ],
+    
+    'audits_extend' => [
+        // eg. \Filament\Tables\Columns\TextColumn::make('url'),
     ]
 
 ];
@@ -64,6 +68,25 @@ public static function getRelations(): array
 That's it, you're all set!
 
 If you access your resource, and edit some data, you will now see the audits table on edit and view pages.
+
+### Extending Columns
+In case you need to add a column to the AuditsRelationManager that does
+not already exist in the table, you can add it in the config, and it will be
+prepended to the table builder.
+
+```php
+<?php
+
+return [
+
+    'audits_extend' => [
+       \Filament\Tables\Columns\TextColumn::make('url'),
+       \Filament\Tables\Columns\TextColumn::make('ip_address'),
+    ]
+
+];
+```
+
 
 ### Permissions
 

--- a/config/filament-auditing.php
+++ b/config/filament-auditing.php
@@ -17,7 +17,14 @@ return [
      *
      */
     'audits_extend' => [
-        // eg. \Filament\Tables\Columns\TextColumn::make('url'),
+        // 'url' => [
+        //     'class' => \Filament\Tables\Columns\TextColumn::class,
+        //     'methods' => [
+        //         'sortable',
+        //         'searchable' => true,
+        //         'default' => 'N/A'
+        //     ]
+        // ],
     ]
 
 ];

--- a/config/filament-auditing.php
+++ b/config/filament-auditing.php
@@ -5,6 +5,10 @@ return [
     'audits_sort' => [
         'column' => 'created_at',
         'direction' => 'desc',
+    ],
+
+    'audits_extend' => [
+        // eg. \Filament\Tables\Columns\TextColumn::make('url),
     ]
 
 ];

--- a/config/filament-auditing.php
+++ b/config/filament-auditing.php
@@ -7,8 +7,17 @@ return [
         'direction' => 'desc',
     ],
 
+    /**
+     *  Extending Columns
+     * --------------------------------------------------------------------------
+     *  In case you need to add a column to the AuditsRelationManager that does
+     *  not already exist in the table, you can add it here, and it will be
+     *  prepended to the table builder.
+     *
+     *
+     */
     'audits_extend' => [
-        // eg. \Filament\Tables\Columns\TextColumn::make('url),
+        // eg. \Filament\Tables\Columns\TextColumn::make('url'),
     ]
 
 ];

--- a/src/RelationManagers/AuditsRelationManager.php
+++ b/src/RelationManagers/AuditsRelationManager.php
@@ -34,7 +34,7 @@ class AuditsRelationManager extends RelationManager
     public static function table(Table $table): Table
     {
         return $table
-            ->columns([
+            ->columns(Arr::flatten([
                 Tables\Columns\TextColumn::make('user.name'),
                 Tables\Columns\TextColumn::make('event'),
                 Tables\Columns\TextColumn::make('created_at')
@@ -43,7 +43,8 @@ class AuditsRelationManager extends RelationManager
                     ->view('filament-auditing::tables.columns.key-value'),
                 Tables\Columns\ViewColumn::make('new_values')
                     ->view('filament-auditing::tables.columns.key-value'),
-            ])
+                config('filament-auditing.audits_extend')
+            ]))
             ->filters([
                 //
             ])


### PR DESCRIPTION
There are columns that somebody may want to be added to the Relation Manager without editing the component in the vendor folder. So this PR adds the ability to add columns they'd like to add to the Relation Manager via the config file. 