### PR TITLE
Dispatch event when audit is restored

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,3 +125,20 @@ Two permissions are registered by default, allowing access to:
 - `restoreAudit`: restore audits
 
 You can override these permissions by adding a policy with `audit` and `restoreAudit`.
+
+### Event emitted
+
+The `auditRestored` event is emitted when an audit is restored, so you could register a listener using the $listeners property to execute some extra code after the audit is restored.
+
+E.g.: on Edit page of your resource:
+
+```php
+protected $listeners = [
+    'auditRestored',
+];
+
+public function auditRestored()
+{
+    // your code
+}
+```

--- a/src/RelationManagers/AuditsRelationManager.php
+++ b/src/RelationManagers/AuditsRelationManager.php
@@ -68,7 +68,10 @@ class AuditsRelationManager extends RelationManager
                     ->action(fn (Audit $record) => static::restoreAuditSelected($record))
                     ->icon('heroicon-o-refresh')
                     ->requiresConfirmation()
-                    ->visible(fn (Audit $record): bool => auth()->user()->can('restoreAudit', $record) && $record->event === 'updated'),
+                    ->visible(fn (Audit $record): bool => auth()->user()->can('restoreAudit', $record) && $record->event === 'updated')
+                    ->after(function ($livewire) {
+                        $livewire->emit('auditRestored');
+                    }),
             ])
             ->bulkActions([
                 //


### PR DESCRIPTION
Emit the `auditRestored` event, when an audit is restored, so it could be used for e.g. on Edit page to execute some code.