### PR TITLE
Fix type error if implement custom model Audit

### DIFF
--- a/src/RelationManagers/AuditsRelationManager.php
+++ b/src/RelationManagers/AuditsRelationManager.php
@@ -12,7 +12,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Arr;
-use OwenIt\Auditing\Models\Audit;
+use OwenIt\Auditing\Contracts\Audit;
 
 class AuditsRelationManager extends RelationManager
 {


### PR DESCRIPTION
Change type injection to `OwenIt\Auditing\Contracts\Audit` rather than `OwenIt\Auditing\Models\Audit`. this will solve type error problem if we create custom model and change config audit implementation model in `audit.php`