### PR TITLE
Key/Value column view supports attach / detach

### DIFF
--- a/resources/views/tables/columns/key-value.blade.php
+++ b/resources/views/tables/columns/key-value.blade.php
@@ -1,8 +1,16 @@
 <div class="my-2 text-sm font-medium tracking-tight">
     @foreach($getState() as $key => $value)
-        <span class="inline-block p-1 mr-1 rounded-md whitespace-normal text-gray-700 bg-gray-500/10">
+        <span class="inline-block p-1 mr-1 rounded-md whitespace-normal text-gray-700 dark:text-gray-200 bg-gray-500/10">
             {{ $key }}
         </span>
-        {{ $value }}
+        @unless(is_array($value))
+            {{ $value }}
+        @else
+            <span class="divide-x divide-solid divide-gray-200 dark:divide-gray-700">
+                @foreach ($value as $nestedValue)
+                    {{$nestedValue['id']}}
+                @endforeach
+            </span>
+        @endunless
     @endforeach
 </div>


### PR DESCRIPTION
Laravel Auditing 13 allows for tracking related (many/many) changes in Audit History: https://laravel-auditing.com/guide/audit-custom.html#example-related-attributes

Part of this changes includes attaching and detaching these relationships, which causes the `old_values` column to contain a nested array. However, the default Key/Value view doesn't support a nested array like this and throws a `TypeError` of: `htmlspecialchars(): Argument #1 ($string) must be of type string, array given`

The included change is a quick fix that checks to see if there is indeed a nested array and if so displays the list of attached/detached IDs. I've also included some classes for minor Dark Mode support.