### PR TITLE
Save JSON fields as correct type, not string

### DIFF
--- a/src/RelationManagers/AuditsRelationManager.php
+++ b/src/RelationManagers/AuditsRelationManager.php
@@ -128,6 +128,15 @@ class AuditsRelationManager extends RelationManager
         Arr::pull($restore, 'id');
 
         if (is_array($restore)) {
+
+            foreach ($restore as $key => $item) {
+                $decode = json_decode($item);
+
+                if (json_last_error() === JSON_ERROR_NONE) {
+                    $restore[$key] = $decode;
+                }
+            }
+
             $record->fill($restore);
             $record->save();
 


### PR DESCRIPTION
When restoring audits, JSON fields are saved as strings and this currently causes breaking changes, as JSON types are no longer valid.

Instead, this PR persists them as valid json by overwriting the value to the `$restore` array, before saving the fields to the database.