### PR TITLE
Ensure it does not break with null values.

### DIFF
--- a/resources/views/tables/columns/key-value.blade.php
+++ b/resources/views/tables/columns/key-value.blade.php
@@ -1,5 +1,5 @@
 <div class="my-2 text-sm font-medium tracking-tight">
-    @foreach($getState() as $key => $value)
+    @foreach($getState() ?? [] as $key => $value)
         <span class="inline-block p-1 mr-1 rounded-md whitespace-normal text-gray-700 dark:text-gray-200 bg-gray-500/10">
             {{ $key }}
         </span>


### PR DESCRIPTION
There's a case where the old value can be null, this simply checks/defaults to an empty array.