### PR TITLE
Allow multiple parameter methods when extending columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,25 @@ After adding this information in the config, please run this command for changes
 php artisan optimize
 ```
 
-As things stand, methods with two required parameters are not supported.
+Methods with two or more parameters can be specified with an array like so:
+
+```php
+<?php
+
+return [
+
+    'audits_extend' => [
+       'created_at' => [
+           'class' => \Filament\Tables\Columns\TextColumn::class, // required
+           'methods' => [
+               'sortable',
+               'date' => ['Y-m-d H:i:s', 'America/New_York'],
+            ],
+        ],
+    ]
+
+];
+```
 
 ### Custom View Data Formatting
 

--- a/src/RelationManagers/AuditsRelationManager.php
+++ b/src/RelationManagers/AuditsRelationManager.php
@@ -135,7 +135,7 @@ class AuditsRelationManager extends RelationManager
                                 return $columnClass->$value();
                             }
 
-                            return $columnClass->$key(...Arr::map($value));
+                            return $columnClass->$key(...Arr::wrap($value));
                         });
 
                         return $columnClass;

--- a/src/RelationManagers/AuditsRelationManager.php
+++ b/src/RelationManagers/AuditsRelationManager.php
@@ -135,7 +135,7 @@ class AuditsRelationManager extends RelationManager
                                 return $columnClass->$value();
                             }
 
-                            return $columnClass->$key($value);
+                            return $columnClass->$key(...Arr::map($value));
                         });
 
                         return $columnClass;


### PR DESCRIPTION
Previously it was not possible to use multiple parameter methods when extending columns. This PR allows you to use an array to provide multiple parameters to method, like so:

```php
<?php

return [

    'audits_extend' => [
       'created_at' => [
           'class' => \Filament\Tables\Columns\TextColumn::class,
           'methods' => [
               'sortable',
               'date' => ['Y-m-d H:i:s', 'America/New_York'],
            ],
        ],
    ]

];
```