### PR TITLE
fix(relation-manager): eager load auditable relation to properly parse restoreAudit permission

### DIFF
--- a/src/RelationManagers/AuditsRelationManager.php
+++ b/src/RelationManagers/AuditsRelationManager.php
@@ -65,7 +65,7 @@ class AuditsRelationManager extends RelationManager
 
         return $table
             ->recordTitle(fn (Model $record): string => 'Audit')
-            ->modifyQueryUsing(fn (Builder $query) => $query->with('user')->orderBy(config('filament-auditing.audits_sort.column'), config('filament-auditing.audits_sort.direction')))
+            ->modifyQueryUsing(fn (Builder $query) => $query->with(['user', 'auditable'])->orderBy(config('filament-auditing.audits_sort.column'), config('filament-auditing.audits_sort.direction')))
             ->content(fn (): ?View => config('filament-auditing.custom_audits_view') ? view('filament-auditing::tables.custom-audit-content', Arr::add(self::customViewParameters(), 'owner', $this->getOwnerRecord())) : null)
             ->emptyStateHeading(trans('filament-auditing::filament-auditing.table.empty_state_heading'))
             ->columns(Arr::flatten([


### PR DESCRIPTION
I noticed that on v4 the action [RestoreAuditAction](https://github.com/TappNetwork/filament-auditing/blob/4.x/src/Filament/Actions/RestoreAuditAction.php#L46) is now accessing the `auditable` relation of the record in order to check the `restoreAudit` permission:

```
->visible(fn (Audit $record): bool => Filament::auth()->user()->can('restoreAudit', $record->auditable) && $record->event === 'updated')
```

Previously, on v3, this was done on [AuditsRelationManager](https://github.com/TappNetwork/filament-auditing/blob/main/src/RelationManagers/AuditsRelationManager.php#L93) by injecting the RelationManager instance and accessing the `ownerRecord`.

```
->visible(fn (Audit $record, RelationManager $livewire): bool => Filament::auth()->user()->can('restoreAudit', $livewire->ownerRecord) && $record->event === 'updated')
```

This change is now causing the relation `auditable` to be lazy loaded, which can cause either the N+1 problem with unnecessary queries or throw a `LazyLoadingViolationException` if `preventLazyLoading` is enabled on the project (my case).

One solution would be reverting to how it was done before, accessing the ownerRecord. Even though it works, I don't think it's a 100% safe solution, because it assumes the audit entry being displayed is actually related to that owner record. There might be some scenarios where this is not true (users reusing components of this package or something).

So the safest solution would be eager loading the `auditable` relation when building the table.