### PR TITLE
fix(views): properly display boolean values

### DIFF
--- a/resources/views/infolists/components/audit-values-entry.blade.php
+++ b/resources/views/infolists/components/audit-values-entry.blade.php
@@ -11,15 +11,17 @@
                            {{ Str::title($key) }}:
                         </span>
                         <span class="font-semibold">
-                            @unless(is_array($value))
-                                {{ $value }}
-                            @else
+                            @if(is_array($value))
                                 <span class="divide-x divide-solid divide-gray-200 dark:divide-gray-700">
                                     @foreach ($value as $nestedValue)
                                         {{ $nestedValue['id'] }}
                                     @endforeach
                                 </span>
-                            @endunless
+                            @elseif (is_bool($value))
+                                {{ $value ? 'true' : 'false' }}
+                            @else
+                                {{ $value }}
+                            @endif
                         </span>
                     </li>
                 @endforeach

--- a/resources/views/tables/columns/audit-values-column.blade.php
+++ b/resources/views/tables/columns/audit-values-column.blade.php
@@ -11,15 +11,17 @@
                        {{ Str::title($key) }}:
                     </span>
                     <span class="font-semibold">
-                        @unless(is_array($value))
-                            {{ $value }}
-                        @else
+                        @if(is_array($value))
                             <span class="divide-x divide-solid divide-gray-200 dark:divide-gray-700">
                                 @foreach ($value as $nestedValue)
                                     {{ $nestedValue['id'] }}
                                 @endforeach
                             </span>
-                        @endunless
+                        @elseif (is_bool($value))
+                            {{ $value ? 'true' : 'false' }}
+                        @else
+                            {{ $value }}
+                        @endif
                     </span>
                 </li>
             @endforeach

--- a/resources/views/tables/columns/key-value.blade.php
+++ b/resources/views/tables/columns/key-value.blade.php
@@ -10,15 +10,17 @@
                     {{ Str::title($key) }}:
                 </span>
                 <span class="font-semibold">
-                    @unless(is_array($value))
-                        {{ $value }}
-                    @else
+                    @if(is_array($value))
                         <span class="divide-x divide-solid divide-gray-200 dark:divide-gray-700">
                             @foreach ($value as $nestedValue)
                                 {{$nestedValue['id']}}
                             @endforeach
                         </span>
-                    @endunless
+                    @elseif (is_bool($value))
+                        {{ $value ? 'true' : 'false' }}
+                    @else
+                        {{ $value }}
+                    @endif
                 </span>
             </li>
         @endforeach


### PR DESCRIPTION
Boolean values were not being properly displayed on the templates, especially `false` which resolved to an empty string, making the user consider if the field was empty or false.

This small change will properly display a true/false string.