### PR TITLE
fix: hardcoded label in infolist

### DIFF
--- a/resources/lang/en/filament-auditing.php
+++ b/resources/lang/en/filament-auditing.php
@@ -59,6 +59,7 @@ return [
     'infolist.ip-address' => 'IP Address',
     'infolist.user-agent' => 'User Agent',
     'infolist.tags' => 'Tags',
+    'infolist.field' => 'Field',
 
     /*
     |--------------------------------------------------------------------------

--- a/src/Filament/Resources/Audits/Schemas/AuditInfolist.php
+++ b/src/Filament/Resources/Audits/Schemas/AuditInfolist.php
@@ -48,13 +48,13 @@ class AuditInfolist
                             ->schema([
                                 KeyValueEntry::make('old_values')
                                     ->hiddenLabel()
-                                    ->keyLabel('Field'),
+                                    ->keyLabel(trans('filament-auditing::filament-auditing.infolist.field')),
                             ]),
                         Tab::make(trans('filament-auditing::filament-auditing.infolist.tab.new-values'))
                             ->schema([
                                 KeyValueEntry::make('new_values')
                                     ->hiddenLabel()
-                                    ->keyLabel('Field'),
+                                    ->keyLabel(trans('filament-auditing::filament-auditing.infolist.field')),
                             ]),
                     ]),
             ]);


### PR DESCRIPTION
This pull request removes a hardcoded UI label ("Field") and replaces it with a translation key.