### PR TITLE
Fix ArgumentCountError when the audited model is missing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /node_modules
 /vendor
+.phpunit.cache
 .phpunit.result.cache
 Homestead.json
 Homestead.yaml

--- a/src/Filament/Actions/RestoreAuditAction.php
+++ b/src/Filament/Actions/RestoreAuditAction.php
@@ -43,7 +43,9 @@ class RestoreAuditAction extends Action
                     ]),
             ])
             ->requiresConfirmation()
-            ->visible(fn (Audit $record): bool => Filament::auth()->user()->can('restoreAudit', $record->auditable) && $record->event === 'updated')
+            ->visible(fn (Audit $record): bool => $record->auditable !== null
+                && $record->event === 'updated'
+                && Filament::auth()->user()->can('restoreAudit', $record->auditable))
             ->after(function ($livewire) {
                 $livewire->dispatch('auditRestored');
             });

--- a/src/Filament/Resources/Audits/AuditResource.php
+++ b/src/Filament/Resources/Audits/AuditResource.php
@@ -8,6 +8,7 @@ use Filament\Schemas\Schema;
 use Filament\Support\Icons\Heroicon;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Str;
 use Tapp\FilamentAuditing\Filament\Resources\Audits\Pages\ListAudits;
 use Tapp\FilamentAuditing\Filament\Resources\Audits\Pages\ViewAudit;
 use Tapp\FilamentAuditing\Filament\Resources\Audits\Schemas\AuditInfolist;
@@ -48,7 +49,7 @@ class AuditResource extends Resource
 
         $tenantModel = config('filament-auditing.tenancy.model');
 
-        return \Illuminate\Support\Str::snake(class_basename($tenantModel));
+        return Str::snake(class_basename($tenantModel));
     }
 
     public static function infolist(Schema $schema): Schema

--- a/src/FilamentAuditingServiceProvider.php
+++ b/src/FilamentAuditingServiceProvider.php
@@ -27,12 +27,14 @@ class FilamentAuditingServiceProvider extends PackageServiceProvider
     {
         parent::packageBooted();
 
-        // Default values for view and restore audits. Add a policy to override these values
-        Gate::define('audit', function ($user, $resource) {
+        // Default values for view and restore audits. Add a policy to override these values.
+        // The resource is optional because the audited model may no longer be
+        // retrievable, e.g. when it has been deleted or soft deleted.
+        Gate::define('audit', function ($user, mixed $resource = null): bool {
             return true;
         });
 
-        Gate::define('restoreAudit', function ($user, $resource) {
+        Gate::define('restoreAudit', function ($user, mixed $resource = null): bool {
             return true;
         });
 

--- a/src/Models/Audit.php
+++ b/src/Models/Audit.php
@@ -3,6 +3,7 @@
 namespace Tapp\FilamentAuditing\Models;
 
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Str;
 use OwenIt\Auditing\Models\Audit as BaseAudit;
 
 class Audit extends BaseAudit
@@ -24,7 +25,7 @@ class Audit extends BaseAudit
                 if (! $tenantColumn) {
                     $relationshipName = config('filament-auditing.tenancy.relationship_name');
                     if (! $relationshipName) {
-                        $relationshipName = \Illuminate\Support\Str::snake(class_basename($tenantModel));
+                        $relationshipName = Str::snake(class_basename($tenantModel));
                     }
                     $tenantColumn = $relationshipName.'_id';
                 }
@@ -49,7 +50,7 @@ class Audit extends BaseAudit
             return 'tenant';
         }
 
-        return \Illuminate\Support\Str::snake(class_basename($tenantModel));
+        return Str::snake(class_basename($tenantModel));
     }
 
     /**

--- a/tests/AuditAbilitiesTest.php
+++ b/tests/AuditAbilitiesTest.php
@@ -1,0 +1,20 @@
+<?php
+
+use Illuminate\Foundation\Auth\User;
+use Illuminate\Support\Facades\Gate;
+
+beforeEach(function () {
+    $this->user = new class extends User {};
+});
+
+it('authorizes audit abilities when the audited model is available', function (string $ability) {
+    expect(Gate::forUser($this->user)->allows($ability, $this->user))->toBeTrue();
+})->with(['audit', 'restoreAudit']);
+
+it('authorizes audit abilities when the audited model is unavailable', function (string $ability) {
+    expect(Gate::forUser($this->user)->allows($ability))->toBeTrue();
+})->with(['audit', 'restoreAudit']);
+
+it('denies audit abilities for guests', function (string $ability) {
+    expect(Gate::forUser(null)->allows($ability))->toBeFalse();
+})->with(['audit', 'restoreAudit']);


### PR DESCRIPTION
# Details

The default audit and restoreAudit gates required a second argument. Laravel Auditing’s auditable relation is morphTo() without `withTrashed()`, so $record->auditable is null when the related model has been deleted or soft-deleted. Filament then called `can('restoreAudit', null)` while rendering the audits table, which invoked the gate with only the user and threw:

Too few arguments to function … FilamentAuditingServiceProvider::packageBooted() … 1 passed … exactly 2 expected

This matches [TappNetwork/filament-auditing#67](https://github.com/TappNetwork/filament-auditing/issues/67).

This PR make the resource argument optional on both gates so a missing auditable does not crash. Hide the restore action unless the auditable still exists and the event is updated. This follows Laravel Auditing: `$audit->auditable` may be null by default; apps that need soft-deleted models can opt into a custom Audit model with `withTrashed()` via `config/audit.php` implementation. Hard-deleted models remain null either way, and restore still requires a live record.
