### PR TITLE
Fix audits table crash on scalar nested IDs

### DIFF
--- a/resources/views/infolists/components/audit-values-entry.blade.php
+++ b/resources/views/infolists/components/audit-values-entry.blade.php
@@ -14,7 +14,7 @@
                             @if(is_array($value))
                                 <span class="divide-x divide-solid divide-gray-200 dark:divide-gray-700">
                                     @foreach ($value as $nestedValue)
-                                        {{ $nestedValue['id'] }}
+                                        {{ \Tapp\FilamentAuditing\Support\AuditValueFormatter::nested($nestedValue) }}
                                     @endforeach
                                 </span>
                             @elseif (is_bool($value))

--- a/resources/views/tables/columns/audit-values-column.blade.php
+++ b/resources/views/tables/columns/audit-values-column.blade.php
@@ -14,7 +14,7 @@
                         @if(is_array($value))
                             <span class="divide-x divide-solid divide-gray-200 dark:divide-gray-700">
                                 @foreach ($value as $nestedValue)
-                                    {{ $nestedValue['id'] }}
+                                    {{ \Tapp\FilamentAuditing\Support\AuditValueFormatter::nested($nestedValue) }}
                                 @endforeach
                             </span>
                         @elseif (is_bool($value))

--- a/resources/views/tables/columns/key-value.blade.php
+++ b/resources/views/tables/columns/key-value.blade.php
@@ -13,7 +13,7 @@
                     @if(is_array($value))
                         <span class="divide-x divide-solid divide-gray-200 dark:divide-gray-700">
                             @foreach ($value as $nestedValue)
-                                {{$nestedValue['id']}}
+                                {{ \Tapp\FilamentAuditing\Support\AuditValueFormatter::nested($nestedValue) }}
                             @endforeach
                         </span>
                     @elseif (is_bool($value))

--- a/src/Support/AuditValueFormatter.php
+++ b/src/Support/AuditValueFormatter.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Tapp\FilamentAuditing\Support;
+
+class AuditValueFormatter
+{
+    /**
+     * Format a nested audit value for display.
+     *
+     * Related-model snapshots may store `['id' => 1]` maps, while many
+     * attributes store a plain list of IDs such as `[1, 2, 3]`.
+     */
+    public static function nested(mixed $value): string
+    {
+        if (is_array($value)) {
+            if (array_key_exists('id', $value)) {
+                return static::nested($value['id']);
+            }
+
+            $encoded = json_encode($value);
+
+            return $encoded === false ? '' : $encoded;
+        }
+
+        if (is_bool($value)) {
+            return $value ? 'true' : 'false';
+        }
+
+        if ($value === null) {
+            return '';
+        }
+
+        if (is_scalar($value)) {
+            return (string) $value;
+        }
+
+        $encoded = json_encode($value);
+
+        return $encoded === false ? '' : $encoded;
+    }
+}

--- a/tests/AuditValueFormatterTest.php
+++ b/tests/AuditValueFormatterTest.php
@@ -1,0 +1,21 @@
+<?php
+
+use Tapp\FilamentAuditing\Support\AuditValueFormatter;
+
+it('formats nested related model maps by id', function () {
+    expect(AuditValueFormatter::nested(['id' => 42]))->toBe('42');
+});
+
+it('formats scalar relationship ids', function (mixed $value, string $expected) {
+    expect(AuditValueFormatter::nested($value))->toBe($expected);
+})->with([
+    'integer' => [7, '7'],
+    'string' => ['01abc', '01abc'],
+    'true' => [true, 'true'],
+    'false' => [false, 'false'],
+    'null' => [null, ''],
+]);
+
+it('json-encodes nested arrays without an id key', function () {
+    expect(AuditValueFormatter::nested(['name' => 'Coach']))->toBe('{"name":"Coach"}');
+});


### PR DESCRIPTION
# Details

The audits table 500s with `Trying to access array offset on int` when a nested audit value is a scalar ID instead of `['id' => n]`.

This showed up on BabbleHQ at `/admin/{org}/audits` (Nightwatch issue 8). Related-model snapshots sometimes store `['id' => 42]`, but many attributes store a plain list such as `[1, 2, 3]`. The old views always did `$nestedValue['id']`.

`v4.1.0` does not include this fix (that release is Laravel 13 / missing-model gate work).

This adds `AuditValueFormatter::nested()` and uses it in the table column, key-value column, and infolist entry.